### PR TITLE
added hashbang, set -e, and removeFunc to coverage.sh

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -1,15 +1,22 @@
+#!/usr/bin/env bash
+
+# exit if anything fails
+set -e
+
+function removeCoverageOut () {
+    if [ -f coverage.out ]
+    then
+        echo "REMOVING coverage.out"
+        rm coverage.out
+    fi
+}
+
 # delete previous coverage report, if it exists
-if [ -f coverage.out ]
-then
-    rm coverage.out
-fi
+removeCoverageOut
 
 # run tests
 go test -coverprofile=coverage.out
 go tool cover -html=coverage.out
 
 # delete the new coverage report, if it exists, so I don't accidentally commit it to the repo somehow
-if [ -f coverage.out ]
-then
-    rm coverage.out
-fi
+removeCoverageOut


### PR DESCRIPTION
Added a few little things to this shell script to beef it up a bit.

- `env` based #!
- `set -e` so the script exists on any error, instead of continuing as the (odd) default of shell scripts
- created a function for removeCoverageOut to DRY things up a bit.